### PR TITLE
reserved server-env, when cleared document root (www)

### DIFF
--- a/vendor/server.js
+++ b/vendor/server.js
@@ -200,6 +200,29 @@ exports.start = function(opt, callback) {
   });
 };
 
-/*exports.clean = function() {
+exports.clean = function(options) {
+  var argExclude = options.exclude || [];
 
-};*/
+  if (!Array.isArray(argExclude)) {
+    argExclude = [argExclude];
+  }
+
+  // merge command args
+  var exclude = [
+    '/fisdata/**',
+    '/index.php',
+    '/rewrite/**',
+    '/server.log',
+    '/smarty/**',
+    '/WEB-INF/**',
+    '/php-simulation-env/**',
+    '/welcome.php'
+  ].concat(argExclude);
+
+  // because fis.util.glob beginning with `^/`，so need fix it.
+  exclude = exclude.map(function (fix) {
+    return options.root + fix;
+  });
+  
+  fis.util.del(options.root, options.include || fis.get('server.clean.include'), exclude);
+};


### PR DESCRIPTION
现在不进行解决方案封装的话，用户配置的 `server.clean.exclude` 根本就形同虚设，包括 `fis3-smarty` 这样的机制。

因为压根在 `fis3 server` 阶段没有读取 `fis-conf.js` 的逻辑，也不应该有。

所以，这块逻辑还需要进一步的整理一下。

有个用户遇到 windows [clean 的时候进程占用报错的问题](https://github.com/fex-team/fis/issues/565#issuecomment-203718422)，所以随手就修复了一把。

另外，当处理这块逻辑的时候，现在的 `_.glob` 产出的正则是呆 `/^` 的，所以还需要把**路径补全**才能正常工作，此次修改并**没有在 windows 上测试**。
